### PR TITLE
Add premium page

### DIFF
--- a/premium/index.html
+++ b/premium/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fit2Go Premium</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="hero">
+        <img src="../Fit2Go Logo (White & Green, Transparent BG).png" alt="Fit2Go Logo" class="logo">
+        <h1>Premium In‑Home & Virtual Training</h1>
+        <p>Automate your fitness with expert coaching that fits your schedule.</p>
+    </header>
+    <section class="features">
+        <h2>Why Fit2Go?</h2>
+        <div class="feature">
+            <h3>Habit-Based Coaching</h3>
+            <p>Build automatic routines that remove decision fatigue and make workouts inevitable.</p>
+        </div>
+        <div class="feature">
+            <h3>3‑Phase Goal System</h3>
+            <p>Clarity, Commitment, Coaching – our proven framework to turn your goals into action.</p>
+        </div>
+        <div class="feature">
+            <h3>Convenience-First Training</h3>
+            <p>We bring elite trainers to your home or office, with programs tailored to your space and time.</p>
+        </div>
+        <div class="feature">
+            <h3>Virtual & On‑Demand Workouts</h3>
+            <p>Access personalized sessions online, plus quick 3-minute routines when life gets hectic.</p>
+        </div>
+    </section>
+    <section class="media">
+        <h2>As Seen On</h2>
+        <ul>
+            <li>FOX45 News – Automate Your Fitness Routine</li>
+            <li>ACE Fitness – Maximizing Downtime</li>
+            <li>SparkPeople – 6 Ways to Maximize a Short Workout</li>
+            <li>U.S. News & World Report – The Best Fitness Apps</li>
+        </ul>
+    </section>
+    <section class="about">
+        <img src="../Dani Headshot (Final).jpg" alt="Dani Singer" class="headshot">
+        <div>
+            <h2>Dani Singer, CEO</h2>
+            <p>Nationally recognized trainer featured in Reader's Digest, SELF, and more.</p>
+        </div>
+    </section>
+    <footer>
+        <p>&copy; 2024 Fit2Go Personal Training</p>
+    </footer>
+</body>
+</html>

--- a/premium/style.css
+++ b/premium/style.css
@@ -1,0 +1,63 @@
+body {
+    margin: 0;
+    font-family: Arial, Helvetica, sans-serif;
+    color: #333;
+    line-height: 1.6;
+    background-color: #f5f5f5;
+}
+
+.hero {
+    background: linear-gradient(135deg, #65bd60, #179a16);
+    color: #fff;
+    text-align: center;
+    padding: 40px 20px;
+}
+.hero .logo {
+    width: 150px;
+    height: auto;
+}
+.features {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 20px;
+    padding: 40px 20px;
+    background-color: #fff;
+}
+.feature {
+    flex: 1 1 250px;
+    background-color: #e8ffe7;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.media {
+    background-color: #f0f0f0;
+    padding: 40px 20px;
+    text-align: center;
+}
+.media ul {
+    list-style: none;
+    padding: 0;
+}
+.media li {
+    margin: 10px 0;
+}
+.about {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
+    padding: 40px 20px;
+    background-color: #fff;
+}
+.about .headshot {
+    width: 200px;
+    border-radius: 50%;
+}
+footer {
+    text-align: center;
+    padding: 20px;
+    background-color: #222;
+    color: #fff;
+}


### PR DESCRIPTION
## Summary
- add premium landing page with a logo hero and sections for features, media mentions, and founder headshot
- style the new page with a simple responsive layout

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685b9b3f7eb8832aa3f21c636fa76aaf