### PR TITLE
Add elite Fit2Go Partner Property landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,422 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Fit2Go Partner Property | Wellness Real Estate Advantage</title>
+  <meta name="description" content="Turn underused amenities into premium wellness experiences with Fit2Go. Zero-cost activation, insured operations, resident retention, and new revenue for luxury properties." />
+  <style>
+    :root {
+      --bg: #090d10;
+      --bg-soft: #10171d;
+      --ink: #f2f5f7;
+      --muted: #a9b7c2;
+      --brand: #7CFF4D;
+      --brand-2: #2fc7ff;
+      --card: rgba(255, 255, 255, 0.04);
+      --stroke: rgba(255, 255, 255, 0.15);
+      --gold: #f9d77e;
+      --shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+      --radius: 18px;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: Inter, Avenir, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+      background:
+        radial-gradient(circle at 80% -10%, rgba(47, 199, 255, 0.15), transparent 35%),
+        radial-gradient(circle at 15% 10%, rgba(124, 255, 77, 0.10), transparent 30%),
+        var(--bg);
+      color: var(--ink);
+      line-height: 1.55;
+    }
+
+    .container {
+      width: min(1200px, 92vw);
+      margin: 0 auto;
+    }
+
+    .hero {
+      position: relative;
+      overflow: hidden;
+      border-bottom: 1px solid var(--stroke);
+      padding: 28px 0 72px;
+    }
+
+    .nav {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 20px;
+      margin-bottom: 48px;
+    }
+
+    .logo {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      font-weight: 700;
+      letter-spacing: .4px;
+    }
+
+    .logo img {
+      width: 44px;
+      height: 44px;
+      object-fit: contain;
+      filter: drop-shadow(0 0 12px rgba(124, 255, 77, .45));
+    }
+
+    .pill {
+      color: var(--ink);
+      border: 1px solid var(--stroke);
+      padding: 8px 14px;
+      border-radius: 999px;
+      font-size: .9rem;
+      background: rgba(255,255,255,.03);
+    }
+
+    .hero-grid {
+      display: grid;
+      grid-template-columns: 1.1fr .9fr;
+      gap: 32px;
+      align-items: center;
+    }
+
+    h1 {
+      margin: 0 0 14px;
+      font-size: clamp(2rem, 4.8vw, 4rem);
+      line-height: 1.06;
+      letter-spacing: -1px;
+    }
+
+    .gradient {
+      background: linear-gradient(90deg, var(--brand), var(--brand-2));
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
+    }
+
+    .lead {
+      color: var(--muted);
+      font-size: clamp(1rem, 1.4vw, 1.22rem);
+      max-width: 62ch;
+      margin: 0 0 26px;
+    }
+
+    .cta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 22px;
+    }
+
+    .btn {
+      border: 0;
+      border-radius: 999px;
+      padding: 12px 20px;
+      font-weight: 700;
+      letter-spacing: .3px;
+      text-decoration: none;
+      transition: transform .2s ease, box-shadow .2s ease;
+    }
+
+    .btn-primary {
+      background: linear-gradient(110deg, var(--brand), #9dff7a);
+      color: #03220d;
+      box-shadow: 0 12px 30px rgba(124, 255, 77, .28);
+    }
+
+    .btn-secondary {
+      background: rgba(255,255,255,.06);
+      color: var(--ink);
+      border: 1px solid var(--stroke);
+    }
+
+    .btn:hover { transform: translateY(-2px); }
+
+    .hero-card {
+      background: linear-gradient(160deg, rgba(255,255,255,.07), rgba(255,255,255,.02));
+      border: 1px solid var(--stroke);
+      border-radius: var(--radius);
+      padding: 24px;
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(4px);
+    }
+
+    .hero-card h3 { margin-top: 0; }
+
+    .metric {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 12px;
+      margin-top: 16px;
+    }
+
+    .metric div {
+      background: var(--card);
+      border: 1px solid rgba(255,255,255,.1);
+      border-radius: 14px;
+      padding: 12px;
+      text-align: center;
+    }
+
+    .metric strong {
+      display: block;
+      font-size: 1.3rem;
+      color: var(--gold);
+    }
+
+    section {
+      padding: 64px 0;
+      border-bottom: 1px solid rgba(255,255,255,.08);
+    }
+
+    .section-title {
+      font-size: clamp(1.5rem, 2.8vw, 2.4rem);
+      margin: 0 0 10px;
+    }
+
+    .section-sub {
+      margin: 0 0 28px;
+      color: var(--muted);
+      max-width: 68ch;
+    }
+
+    .benefits {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(260px, 1fr));
+      gap: 18px;
+    }
+
+    .benefit {
+      background: var(--card);
+      border: 1px solid var(--stroke);
+      border-radius: var(--radius);
+      padding: 18px 18px 16px;
+    }
+
+    .benefit h3 {
+      margin: 0 0 8px;
+      font-size: 1.15rem;
+    }
+
+    .benefit p { margin: 0; color: #d3dde5; }
+
+    .tag {
+      display: inline-block;
+      margin-bottom: 10px;
+      font-size: .78rem;
+      letter-spacing: .35px;
+      text-transform: uppercase;
+      color: #001d0b;
+      background: var(--brand);
+      border-radius: 999px;
+      padding: 6px 10px;
+      font-weight: 700;
+    }
+
+    .split {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 20px;
+    }
+
+    .panel {
+      background: linear-gradient(165deg, rgba(47,199,255,.08), rgba(124,255,77,.05));
+      border: 1px solid var(--stroke);
+      border-radius: var(--radius);
+      padding: 24px;
+    }
+
+    .panel ul {
+      margin: 10px 0 0;
+      padding-left: 20px;
+      color: #d7e2e8;
+    }
+
+    .panel li + li { margin-top: 8px; }
+
+    .final-cta {
+      text-align: center;
+      padding: 74px 0 90px;
+      border-bottom: 0;
+    }
+
+    .final-cta .card {
+      background: linear-gradient(150deg, rgba(124,255,77,.18), rgba(47,199,255,.08));
+      border: 1px solid var(--stroke);
+      border-radius: 24px;
+      padding: 38px;
+      box-shadow: var(--shadow);
+    }
+
+    footer {
+      color: #9db0bc;
+      font-size: .92rem;
+      text-align: center;
+      padding: 18px 0 34px;
+    }
+
+    @media (max-width: 920px) {
+      .hero-grid, .split { grid-template-columns: 1fr; }
+      .benefits { grid-template-columns: 1fr; }
+      .metric { grid-template-columns: 1fr 1fr 1fr; }
+    }
+
+    @media (max-width: 620px) {
+      .metric { grid-template-columns: 1fr; }
+      .hero { padding-bottom: 56px; }
+      section { padding: 52px 0; }
+      .final-cta .card { padding: 28px; }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="container">
+      <nav class="nav" aria-label="Top Navigation">
+        <div class="logo">
+          <img src="Fit2Go Icon (Transparent BG).png" alt="Fit2Go logo" />
+          <span>Fit2Go Partner Properties</span>
+        </div>
+        <span class="pill">Luxury Wellness Activation</span>
+      </nav>
+
+      <div class="hero-grid">
+        <div>
+          <h1>Turn Premium Amenities Into a <span class="gradient">Revenue-Positive Wellness Destination</span>.</h1>
+          <p class="lead">
+            Fit2Go helps luxury properties compete in the modern <strong>wellness real estate</strong> era by activating underused fitness and spa spaces,
+            delivering concierge-level services, and enhancing resident satisfaction — all with <strong>zero cost</strong> and minimal onsite effort.
+          </p>
+          <div class="cta">
+            <a href="#contact" class="btn btn-primary">Become a Partner Property</a>
+            <a href="#benefits" class="btn btn-secondary">View Partner Benefits</a>
+          </div>
+        </div>
+
+        <aside class="hero-card" aria-label="Business impact summary">
+          <h3>What Fit2Go Delivers</h3>
+          <p>
+            We operate as the wellness “software” layered on your existing amenity “hardware,” allowing your property to rival next-generation wellness buildings without expensive renovations.
+          </p>
+          <div class="metric">
+            <div><strong>$0</strong><span>Property Cost</span></div>
+            <div><strong>3-20%</strong><span>Revenue Share Potential</span></div>
+            <div><strong>+1%</strong><span>Retention = Big Savings</span></div>
+          </div>
+        </aside>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section id="benefits">
+      <div class="container">
+        <h2 class="section-title">Core Benefits for Luxury Properties</h2>
+        <p class="section-sub">A premium partnership model designed for property managers who want stronger NOI, better resident experience, and a clear competitive edge.</p>
+
+        <div class="benefits">
+          <article class="benefit">
+            <span class="tag">Amenity Activation</span>
+            <h3>Transform “Ghost Amenities” into Signature Experiences</h3>
+            <p>Dormant spa rooms, outdoor lawns, and high-end gyms become active destinations through staffed massage services, guided yoga classes, and equipment coaching (TRX, Nexersys, and more).</p>
+          </article>
+
+          <article class="benefit">
+            <span class="tag">Zero-Cost Operation</span>
+            <h3>No Added Payroll, No HOA Complexity</h3>
+            <p>Fit2Go handles scheduling, resident billing, and client management independently, giving your residents a high-visibility premium amenity without adding workload to your team.</p>
+          </article>
+
+          <article class="benefit">
+            <span class="tag">Liability Protection</span>
+            <h3>Fully Insured & Risk-Smart by Design</h3>
+            <p>We provide general and professional liability coverage, standardized intake and waivers, and the option to list property management and ownership entities as additional insureds.</p>
+          </article>
+
+          <article class="benefit">
+            <span class="tag">Competitive Positioning</span>
+            <h3>Compete with Wellness-First Developments</h3>
+            <p>Fit2Go gives established properties a fast path to rival purpose-built wellness brands by upgrading the resident wellness ecosystem without structural renovation costs.</p>
+          </article>
+
+          <article class="benefit">
+            <span class="tag">Resident Retention</span>
+            <h3>Increase Renewal Probability Through Lifestyle Value</h3>
+            <p>Exclusive discounts, onboarding fitness orientations, and community events improve resident satisfaction. Even a modest lease-retention bump can produce major savings.</p>
+          </article>
+
+          <article class="benefit">
+            <span class="tag">Ancillary Revenue</span>
+            <h3>Create New NOI-Aligned Revenue Streams</h3>
+            <p>Hybrid revenue-share options can return a percentage of training and spa service revenue back to the property, turning wellness programming into a financial contributor.</p>
+          </article>
+
+          <article class="benefit">
+            <span class="tag">Reputation Lift</span>
+            <h3>Improve ORA and Online Review Performance</h3>
+            <p>Community wellness events can be structured to generate positive resident feedback and stronger amenity narratives in public reviews across key listing platforms.</p>
+          </article>
+
+          <article class="benefit">
+            <span class="tag">Holistic Wellness</span>
+            <h3>Concierge Services Beyond Typical Training</h3>
+            <p>Offer premium integrations like pantry audits, organic meal/fridge stocking for new residents, and fitness-nutrition bridging programs that elevate everyday living.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <div class="container split">
+        <div class="panel">
+          <h3>How the Partner Model Works</h3>
+          <ul>
+            <li>Fit2Go onboardings are coordinated with minimal management lift.</li>
+            <li>All resident sessions and service payments are managed directly by Fit2Go.</li>
+            <li>Programming can be tailored by building profile, resident demographics, and amenity footprint.</li>
+            <li>Performance reporting can support both resident engagement and business-case visibility.</li>
+          </ul>
+        </div>
+
+        <div class="panel">
+          <h3>Ideal for Premium Property Portfolios</h3>
+          <ul>
+            <li>Class A multifamily and luxury lease-up communities.</li>
+            <li>High-rise properties with fitness, spa, or outdoor wellness areas.</li>
+            <li>Corporate operators focused on retention, ORA, and amenity differentiation.</li>
+            <li>Assets seeking a modern wellness identity without capital-intensive buildouts.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="final-cta" id="contact">
+      <div class="container">
+        <div class="card">
+          <h2 class="section-title">Become a Fit2Go Partner Property</h2>
+          <p class="section-sub" style="margin-inline:auto;">
+            Activate underused spaces, protect your building, delight residents, and generate measurable value.
+            Let’s design a custom wellness operating plan for your property.
+          </p>
+          <div class="cta" style="justify-content:center;">
+            <a class="btn btn-primary" href="mailto:partners@fit2go.com?subject=Fit2Go%20Partner%20Property%20Inquiry">Schedule a Partnership Call</a>
+            <a class="btn btn-secondary" href="tel:+13015551234">Call Fit2Go</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    © <span id="year"></span> Fit2Go Personal Training · Wellness Real Estate Partner Program
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a polished, conversion-focused landing page that positions Fit2Go as a turnkey wellness partner for luxury properties facing wellness-real-estate competition. 
- Summarize and promote the core partnership benefits (amenity activation, $0 cost, liability protection, resident retention, ancillary revenue, reputation lift, and concierge wellness services) in a single branded asset. 
- Deliver a self-contained, responsive HTML deliverable that can be dropped into the site or used as a campaign landing page.

### Description
- Added a new `index.html` file that implements a luxury-branded, responsive landing page with embedded CSS and a small JS snippet to display the current year. 
- Built a conversion-focused hero with gradient headline, prominent CTAs (`Become a Partner Property`, `View Partner Benefits`) and a summary impact card showing metrics like `$0 Property Cost` and `3-20% Revenue Share Potential`. 
- Included a benefits grid and supporting panels covering Amenity Activation, Zero-Cost Operation, Liability Protection, Competitive Positioning, Resident Retention, Ancillary Revenue, Reputation Lift, and Holistic Wellness integrations. 
- The page references local brand assets (logo image) and requires no external dependencies or build steps.

### Testing
- Ran a Python `html.parser` parse check on `index.html` which succeeded. 
- No other automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d2ea1cd8cc832aa751bd962f7267fb)